### PR TITLE
Fixes #4 adds ability to close sheet tabs

### DIFF
--- a/src/SheetTabs/SheetTabs.css
+++ b/src/SheetTabs/SheetTabs.css
@@ -18,12 +18,16 @@
   border-radius: 4px 4px 0 0;
   color: rgba(0, 0, 0, 0.65);
   height: 32px;
-  padding: 0 15px;
+  padding: 0 7px 0 15px;
   margin-right: 1px;
   outline: none;
   cursor: pointer;
   display: flex;
   align-items: center;
+}
+
+.SheetTabs_Tab--single {
+  padding: 0 15px;
 }
 
 .SheetTabs_Tab--active {
@@ -37,6 +41,7 @@
 
 .SheetTabs_CloseIcon {
   margin-left: 7px;
+  padding-bottom: 1px;
 }
 
 .SheetTabs_CloseIcon:hover {

--- a/src/SheetTabs/SheetTabs.css
+++ b/src/SheetTabs/SheetTabs.css
@@ -11,7 +11,8 @@
 .SheetTabs_Tab {
   float: left;
   /* Replicate antd buttons */
-  line-height: 1.499;
+  /* line-height: 1.499; */
+  line-height: 32px; /* same height as div so its centered */
   background: #e4e4e4;
   border: 1px solid #d9d9d9;
   border-radius: 4px 4px 0 0;
@@ -21,9 +22,23 @@
   margin-right: 1px;
   outline: none;
   cursor: pointer;
+  display: flex;
+  align-items: center;
 }
 
 .SheetTabs_Tab--active {
   background: #fff;
   border-bottom: none;
+}
+
+.SheetTabs_TabName {
+  margin: 0;
+}
+
+.SheetTabs_CloseIcon {
+  margin-left: 7px;
+}
+
+.SheetTabs_CloseIcon:hover {
+  color: red;
 }

--- a/src/SheetTabs/SheetTabs.tsx
+++ b/src/SheetTabs/SheetTabs.tsx
@@ -1,4 +1,4 @@
-import { Button, Dropdown, Menu } from 'antd';
+import { Button, Dropdown, Menu, Modal } from 'antd';
 import classNames from 'classnames';
 import { inject, observer } from 'mobx-react';
 import React, { Component } from 'react';
@@ -7,6 +7,7 @@ import Sheet from '../Sheet/Sheet';
 import { ProjectStore } from '../stores/project.store';
 import { UiStore } from '../stores/ui.store';
 import './SheetTabs.css';
+import { SheetId } from '../types/SheetTypes';
 
 interface SheetTabsProps {}
 interface InjectedProps extends SheetTabsProps {
@@ -20,15 +21,36 @@ export default class SheetTabs extends Component<SheetTabsProps> {
   get injected() {
     return this.props as InjectedProps;
   }
+
+  confirmSheetTabClosing = (e: React.MouseEvent, sheetId: SheetId) => {
+    e.stopPropagation();
+    // TODO: add the sheet name.
+    Modal.confirm({
+      title: 'Are you sure you want to delete this sheet?',
+      okText: 'Yes',
+      okType: 'danger',
+      cancelText: 'No',
+      onOk: () => this.closeSheetTab(sheetId)
+    });
+  };
+
+  closeSheetTab(sheetId: SheetId) {
+    console.log(`closing sheet id: ${sheetId}`);
+    this.injected.projectStore.removeSheet(sheetId);
+    if (this.injected.uiStore.activeSheet == sheetId) {
+      // TODO: write helper method in project store to determine if a given sheet has a sheet to the right. (handle inside store!)
+    }
+    // if uiStore.currentSheet == sheetId:
+    //   if the current sheet has a sheet to the right,
+    //   set currentSheet to that one.
+    //   if there is one on the left, set currentSheet to that one.
+  }
+
   render() {
     const { uiStore, projectStore } = this.injected;
-    const currentSheet = projectStore.sheetList.find(
-      sheet => sheet.id === uiStore.activeSheet
-    );
-
-    //() => ()
+    const currentSheet = projectStore.getSheet(uiStore.activeSheet);
     const instruments = Audio.getInstrumentNames();
-    const menu = (
+    const instrumentMenu = (
       <Menu
         onClick={param => {
           uiStore.activeSheet = projectStore.addSheet(param.key);
@@ -39,12 +61,13 @@ export default class SheetTabs extends Component<SheetTabsProps> {
         ))}
       </Menu>
     );
+    const displayCloseSheet = projectStore.sheetList.length > 1;
 
     return (
       <div className="SheetTabs">
         <div className="SheetTabs_TabZone">
           {projectStore.sheetList.map(sheet => (
-            <button
+            <div
               className={classNames('SheetTabs_Tab', {
                 'SheetTabs_Tab--active': sheet.id === uiStore.activeSheet
               })}
@@ -52,9 +75,14 @@ export default class SheetTabs extends Component<SheetTabsProps> {
               key={sheet.id}
             >
               {sheet.label}
-            </button>
+              {displayCloseSheet && (
+                <button onClick={e => this.confirmSheetTabClosing(e, sheet.id)}>
+                  x
+                </button>
+              )}
+            </div>
           ))}
-          <Dropdown overlay={menu}>
+          <Dropdown overlay={instrumentMenu}>
             <Button icon="plus" type="primary" ghost />
           </Dropdown>
         </div>

--- a/src/SheetTabs/SheetTabs.tsx
+++ b/src/SheetTabs/SheetTabs.tsx
@@ -24,9 +24,14 @@ export default class SheetTabs extends Component<SheetTabsProps> {
 
   confirmSheetTabClosing = (e: React.MouseEvent, sheetId: SheetId) => {
     e.stopPropagation();
-    // TODO: add the sheet name.
+    const sheetToClose = this.injected.projectStore.getSheet(sheetId);
+    if (!sheetToClose)
+      throw new Error(`Could not find a sheet with id of: ${sheetId}`);
+
     Modal.confirm({
-      title: 'Are you sure you want to delete this sheet?',
+      title: `Are you sure you want to delete the "${
+        sheetToClose.label
+      }" tab sheet?`,
       okText: 'Yes',
       okType: 'danger',
       cancelText: 'No',

--- a/src/SheetTabs/SheetTabs.tsx
+++ b/src/SheetTabs/SheetTabs.tsx
@@ -1,4 +1,4 @@
-import { Button, Dropdown, Menu, Modal } from 'antd';
+import { Button, Dropdown, Menu, Modal, Icon } from 'antd';
 import classNames from 'classnames';
 import { inject, observer } from 'mobx-react';
 import React, { Component } from 'react';
@@ -36,14 +36,21 @@ export default class SheetTabs extends Component<SheetTabsProps> {
 
   closeSheetTab(sheetId: SheetId) {
     console.log(`closing sheet id: ${sheetId}`);
+    const {
+      prevSheet,
+      nextSheet
+    } = this.injected.projectStore.getAdjacentSheets(sheetId);
+
     this.injected.projectStore.removeSheet(sheetId);
-    if (this.injected.uiStore.activeSheet == sheetId) {
-      // TODO: write helper method in project store to determine if a given sheet has a sheet to the right. (handle inside store!)
+
+    // Logic for determining what sheet to focus on when closing the current sheet:
+    if (this.injected.uiStore.activeSheet === sheetId) {
+      if (nextSheet) {
+        this.injected.uiStore.activeSheet = nextSheet;
+      } else if (prevSheet) {
+        this.injected.uiStore.activeSheet = prevSheet;
+      }
     }
-    // if uiStore.currentSheet == sheetId:
-    //   if the current sheet has a sheet to the right,
-    //   set currentSheet to that one.
-    //   if there is one on the left, set currentSheet to that one.
   }
 
   render() {
@@ -74,11 +81,15 @@ export default class SheetTabs extends Component<SheetTabsProps> {
               onClick={() => (uiStore.activeSheet = sheet.id)}
               key={sheet.id}
             >
-              {sheet.label}
+              <p className="SheetTabs_TabName">{sheet.label}</p>
               {displayCloseSheet && (
-                <button onClick={e => this.confirmSheetTabClosing(e, sheet.id)}>
-                  x
-                </button>
+                <Icon
+                  type="close-circle"
+                  className="SheetTabs_CloseIcon"
+                  onClick={(e: React.MouseEvent) =>
+                    this.confirmSheetTabClosing(e, sheet.id)
+                  }
+                />
               )}
             </div>
           ))}

--- a/src/SheetTabs/SheetTabs.tsx
+++ b/src/SheetTabs/SheetTabs.tsx
@@ -40,7 +40,6 @@ export default class SheetTabs extends Component<SheetTabsProps> {
   };
 
   closeSheetTab(sheetId: SheetId) {
-    console.log(`closing sheet id: ${sheetId}`);
     const {
       prevSheet,
       nextSheet
@@ -48,7 +47,6 @@ export default class SheetTabs extends Component<SheetTabsProps> {
 
     this.injected.projectStore.removeSheet(sheetId);
 
-    // Logic for determining what sheet to focus on when closing the current sheet:
     if (this.injected.uiStore.activeSheet === sheetId) {
       if (nextSheet) {
         this.injected.uiStore.activeSheet = nextSheet;

--- a/src/SheetTabs/SheetTabs.tsx
+++ b/src/SheetTabs/SheetTabs.tsx
@@ -81,7 +81,8 @@ export default class SheetTabs extends Component<SheetTabsProps> {
           {projectStore.sheetList.map(sheet => (
             <div
               className={classNames('SheetTabs_Tab', {
-                'SheetTabs_Tab--active': sheet.id === uiStore.activeSheet
+                'SheetTabs_Tab--active': sheet.id === uiStore.activeSheet,
+                'SheetTabs_Tab--single': !displayCloseSheet
               })}
               onClick={() => (uiStore.activeSheet = sheet.id)}
               key={sheet.id}

--- a/src/stores/project.store.ts
+++ b/src/stores/project.store.ts
@@ -38,6 +38,10 @@ export class ProjectStore {
     return id;
   }
 
+  @action removeSheet(sheetId: SheetId) {
+    this.sheetList = this.sheetList.filter(sheet => sheet.id !== sheetId);
+  }
+
   private getUniqueLabelForSheet(instrumentName: string) {
     const instrumentCount = this.sheetList.filter(
       sheet => sheet.instrumentName === instrumentName
@@ -48,7 +52,7 @@ export class ProjectStore {
     return `${instrumentName} ${instrumentCount + 1}`;
   }
 
-  private getSheet(sheetId: SheetId) {
+  public getSheet(sheetId: SheetId) {
     return this.sheetList.find(sheet => sheet.id === sheetId);
   }
 

--- a/src/stores/project.store.ts
+++ b/src/stores/project.store.ts
@@ -56,6 +56,27 @@ export class ProjectStore {
     return this.sheetList.find(sheet => sheet.id === sheetId);
   }
 
+  public getAdjacentSheets(
+    sheetId: SheetId
+  ): { prevSheet: SheetId | null; nextSheet: SheetId | null } {
+    let prevSheet = null;
+    let nextSheet = null;
+
+    for (let i = 0; i < this.sheetList.length; i++) {
+      if (this.sheetList[i].id === sheetId) {
+        if (i !== 0) {
+          prevSheet = this.sheetList[i - 1].id;
+        }
+        if (i + 1 !== this.sheetList.length) {
+          nextSheet = this.sheetList[i + 1].id;
+        }
+        break;
+      }
+    }
+
+    return { prevSheet, nextSheet };
+  }
+
   getFirstElementId(sheetId: SheetId) {
     const sheet = this.getSheet(sheetId);
     if (sheet) {


### PR DESCRIPTION
I used the `ant` library's `close-circle` icon so it doesn't look awful with a un-styled "x" button,  but feel free to update it to use whatever style you think looks best! Just wanted to wrap up our work together so it looked somewhat decent.

Features:
- only shows close tab icon if there is more than a single sheet tab
- you can close a tab that you're not currently on
- closing the current active tab will change the active tab to the next tab (tab to the right) or to the previous tab if there is no right tab
- confirmation modal pops up before you close the tab and also alerts the user the name of the tab that will be closed